### PR TITLE
Fix Anchor in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ You should see a new icon appear to the right of the address bar. Click it to ge
 
 If you right click anywhere on a web page, on a link, or on selected text, you should see "Shellac" in the context menu. (Note that for security reasons, extensions can't modify the context menu on `chrome://*` or `file://*` pages.)
 
-<span name="hacking"></span>
+<a name="hacking"></a>
 ## Writing Your Own Shell Command Actions ##
 
 Edit `etc/shellac.json` and add your custom action. The commands are executed under `/bin/sh -c`. Here's an example:


### PR DESCRIPTION
Super simple patch. The link to hacking in README was broken, it just needed to be an `<a>` instead of a `<span>`.