### PR TITLE
Added ability to run server without a command `cd svc/shellac`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,7 @@ Requirements:
 
 To run the Shellac web app server, do this in a terminal:
 
-    cd svc/shellac
-    ./run
+    ./svc/shellac/run
 
 To install the Chrome extension:
 

--- a/svc/shellac/run
+++ b/svc/shellac/run
@@ -1,3 +1,6 @@
 #!/bin/sh
-cd ../..
+
+filename=`realpath "$(type $0 | awk '{print $3}')"`
+dirpath=`dirname ${filename}`
+cd "$dirpath/../.."
 exec bin/webapp.py 8783


### PR DESCRIPTION
Besides, now it possible to create a command-line launcher, like this:
```sh
sudo ln -s ./svc/shellac/run /usr/local/bin/shellac
```
after that to run server in terminal
```sh
shellac
```